### PR TITLE
parsing capability of the resource/params tag.

### DIFF
--- a/wbuild/scanFiles.py
+++ b/wbuild/scanFiles.py
@@ -92,7 +92,6 @@ def ensureString(elem):
             # make sure each element is a character
             elem = [escapeSMString(item) for item in elem]
             elem = [x for x in elem if str(x).strip() != '']
-
             return ", ".join(elem)
     elif type(elem) is str:
         if "," not in elem:
@@ -100,9 +99,10 @@ def ensureString(elem):
         else:
             return elem
     elif type(elem) is dict:
-        raise TypeError("A wBuild tag is a dict, whereas it can be list or string only. Please check if you have indented"
-                        " all the YAML \'output\' tags in your scripts properly. \nwBuild output should be listed one level deeper than external (knitr) output."
-                        "(The latter one should be on the same level with \'wb\' tag)")
+        elemArr = ["'" + k + "': " + escapeSMString(elem[k]) for k in elem]
+        return "{ " + ", ".join(elemArr) + " }"
+    elif type(elem) is int:
+        return str(elem)
     else:
         raise TypeError("Can't parse type " + str(type(elem)) + "as a valid workflow information under a wBuild YAML tag (input or output).")
 
@@ -183,7 +183,11 @@ def writeRule(r, file):
     else:
         wbInfos["output"] = insertPlaceholders(joinEmpty([ensureString(wbInfos.get("output")), "wBhtml = '" + r['outputFile'] + "'"]), inputFile)
         wbInfos["script"] = "'.wBuild/wBRender.R'"
-
+    
+    for i in SNAKEMAKE_FIELDS:
+        if i not in ['output', 'script', 'input', 'run', 'shell'] and i in wbInfos.keys():
+            wbInfos[i] = ensureString(wbInfos.get(i))
+    
     # remove wb related elements
     # wbInfos = {key: wbInfos[key] for key in wbInfos if key not in WB_FIELDS}
     # if not set(wbInfos.keys()).issubset(SNAKEMAKE_FIELDS):


### PR DESCRIPTION
The resource and params tag of the snakemake field can be a dict. And also they can be quoted by the '`sm' tag.

To enable all fields to be parsed with python code we need to loop over all fields and convert the dictionaries into strings to write them out later into the rule.

Hope this helps to go into the right direction. 

I guess the exception to catch if the 'output' of the knitr part is wrong indented has to go somewhere else, but I do not know where.
